### PR TITLE
Change the way `passenger.processes.used` is calculated

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,16 +150,12 @@ func processUptime(passengerDetails *passengerStatus) Stats {
 }
 
 func processUse(passengerDetails *passengerStatus) int {
-	var totalUsed int
+	var totalSessions int = 0
 	processes := passengerDetails.Processes
-	periodStart := time.Now().Add(-(10 * time.Second))
 	for _, processStats := range processes {
-		lastUsedNano := time.Unix(0, int64(processStats.LastUsed*1000))
-		if lastUsedNano.After(periodStart) {
-			totalUsed += 1
-		}
+		totalSessions += processStats.CurrentSessions
 	}
-	return totalUsed
+	return totalSessions
 }
 
 func chartPendingRequest(passengerDetails *passengerStatus, DogStatsD *godspeed.Godspeed) {


### PR DESCRIPTION
What            | Where/Who
----------------|----------------------------------------
Reviewers       | @mitio @avlazarov 

`passenger.processes.used` was calculated as the number of processes that were used in the last 10 seconds. It turned out that this metric is rather useless, since a worker process will almost surely have been used in the last 10 seconds, so the metric would always report the full number of processes regardless of the actual load on the server.

@mitio [proposed](https://receipt-bank.slack.com/archives/CKG71F6SK/p1560360453032600?thread_ts=1560351069.030100&cid=CKG71F6SK) that we take into account the number of sessions instead. This should give us a better view on the actual load at the moment.